### PR TITLE
chore: downgrade @faststore/cli to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "4.1.2",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/cli",
     "graphql": "^16.11.0",
     "@vtex/faststore-plugin-buyer-portal": "2.0.3",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "4.2.0",
+    "@faststore/cli": "4.1.2",
     "graphql": "^16.11.0",
     "@vtex/faststore-plugin-buyer-portal": "2.0.3",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,11 +1407,6 @@
     "@babel/helper-string-parser" "^7.29.7"
     "@babel/helper-validator-identifier" "^7.29.7"
 
-"@builder.io/partytown@^0.6.1":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.6.4.tgz#8610c9e73cc52a95b963c1878760ebe628eee048"
-  integrity sha512-W6C7O0eSg6YNujHYZozXK5iJ+V69QVLLLRv+NlmYh1vFe0PUJ3kmAhRCx7rUqI3XAA/KpdyfdxLoopBg3GlfVA==
-
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -1553,10 +1548,9 @@
   dependencies:
     fast-deep-equal "^3.1.3"
 
-"@faststore/api@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-4.1.1.tgz#3096aaeace5bc5b055fd9ccfdd7a313b42edd913"
-  integrity sha512-PI6O638jCLyOliS80HluB9fiOTX03ixi3dKiBIWD8HyOAUC+Atsi1XFrMG5+4d44r8D6UfPIAW+3ldK7ZfXNNw==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/api":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/api#927a7c81309c1e494be235dbe099cebd295bcf2f"
   dependencies:
     "@graphql-tools/load-files" "^7.0.0"
     "@graphql-tools/merge" "9.1.1"
@@ -1569,14 +1563,13 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-4.1.2.tgz#d733439075b10c758d1ddb8c14cb08f7fafa87c4"
-  integrity sha512-qI1YWROzDAjMDN70OkX9ErYhK+7sWlOO/xBTayDl50rQrH4P9m1gYKsb+mWiovMeigecyurTmsP5exxEcYy4uQ==
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/cli":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/cli#215e2eebadb2400dfe873bfeda5e79278f043dc8"
   dependencies:
     "@antfu/ni" "0.21.12"
-    "@faststore/api" "4.1.1"
-    "@faststore/core" "4.1.2"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/api"
+    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/core"
     "@graphql-codegen/cli" "6.1.1"
     "@graphql-tools/merge" "9.1.1"
     "@graphql-tools/utils" "10.10.1"
@@ -1597,30 +1590,27 @@
     prettier "^3.1.0"
     resolve-pkg "^3.0.0"
 
-"@faststore/components@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-4.1.1.tgz#0cd9f61b1cf2e535488629a89784db206f3dd304"
-  integrity sha512-vNGwg9zPfT/jGgx09U+Jo140DiPXajcHPKFPfdOUnYF4+MZ8RYbZ2owFeDyr51WN56C7PPfSBehHfXnC93diRA==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/components":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/components#383375968ee47b70af5c6fc6f25dae9ad7e08dcb"
   dependencies:
     react-intersection-observer "^8.32.5"
     react-swipeable "^7.0.0"
 
-"@faststore/core@4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-4.1.2.tgz#001ce40f27a6807830257f011c9e23365e4ff700"
-  integrity sha512-nhxc9W5eZMbC6yY/HBD8RdzQiCeHRQS2ACA5atpiuWtGCfKAtAVXPHA3GNy0QicIZcxo7/5JBoXaryNHfK3q3w==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/core":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/core#b2e3bffcb4d5f4010cc43b85b8abfa5b9aa7c0f0"
   dependencies:
     "@antfu/ni" "0.21.12"
-    "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^5"
     "@envelop/graphql-jit" "^11"
     "@envelop/parser-cache" "^10"
     "@envelop/validation-cache" "^10"
-    "@faststore/api" "4.1.1"
-    "@faststore/diagnostics" "4.1.1"
-    "@faststore/lighthouse" "4.1.1"
-    "@faststore/sdk" "4.1.1"
-    "@faststore/ui" "4.1.1"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/api"
+    "@faststore/diagnostics" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/diagnostics"
+    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/lighthouse"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/ui"
     "@graphql-codegen/cli" "6.1.1"
     "@graphql-codegen/client-preset" "4.2.6"
     "@graphql-codegen/typescript" "4.0.7"
@@ -1638,9 +1628,10 @@
     "@lexical/react" "^0.34.0"
     "@lexical/rich-text" "^0.34.0"
     "@lhci/cli" "^0.15.1"
+    "@qwik.dev/partytown" "^0.14.0"
     "@types/react" "^18.3.27"
     "@vtex/client-cms" "^0.2.16"
-    "@vtex/client-cp" "0.5.1"
+    "@vtex/client-cp" "0.6.0"
     "@vtex/prettier-config" "1.0.0"
     autoprefixer "^10.4.0"
     cookie "^0.7.0"
@@ -1651,6 +1642,7 @@
     fs-extra "^10.1.0"
     idb-keyval "^5.1.3"
     isomorphic-unfetch "^3.1.0"
+    jose "^6.2.3"
     lexical "^0.34.0"
     next "^16.2.6"
     next-seo "^6.6.0"
@@ -1664,36 +1656,32 @@
     swr "^2.2.5"
     use-sync-external-store "^1.6.0"
 
-"@faststore/diagnostics@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/diagnostics/-/diagnostics-4.1.1.tgz#e3066e1fec36d340530b6d220a52802a9c45fb67"
-  integrity sha512-0KHJIeMS+kY0rNEz/CQc/W7D5tyPwyF7GYupyIEjjl3aiTPjtZbIjfgTisaPhGt1gp8PKw8zyb58dscVM7WiNQ==
+"@faststore/diagnostics@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/diagnostics":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/diagnostics#3b359708569c3884c915048aa3771ad9b0c83e26"
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/instrumentation-http" "^0.212.0"
     "@vtex/diagnostics-nodejs" "^5.1.1"
     resolve-pkg "^3.0.1"
 
-"@faststore/lighthouse@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-4.1.1.tgz#7a95d00ef34396e38a00701d8b32c3a3a89fd3c4"
-  integrity sha512-m06Yv579gMOFlNk4Q9/oNenMOayW+22s5uMYsrb1TLlnWfOFm6MSqt0zSRQFDZcdPGJc/l8wVsRmPaVjk1MMFA==
+"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/lighthouse":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/lighthouse#8c02b109d0e19fed5ad0d281f076a397f7930781"
 
-"@faststore/sdk@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-4.1.1.tgz#c6de33c8d15d5a476fe9c247ef956b819d190720"
-  integrity sha512-9le4C2vup8ZpVYB1aU4ZuFGqtIPxtl4FTG4556U357GzNzYvEQ3ObNPsdgzfRFTOpg6am3w7NbbHuf1raLCXlg==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/sdk":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/sdk#d0ff0615b796f6672f21e3103aaa7742e6535490"
   dependencies:
     fast-deep-equal "^3.1.3"
     idb-keyval "^6"
     zustand "^5.0.5"
 
-"@faststore/ui@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-4.1.1.tgz#e385c5f39eebbfaba72ac202ffedf9e992f7e100"
-  integrity sha512-MQs9QFWhkRH63mTIqYl6d30S4e3m2jOZHZPYVDCBW+x1naMIQC5IyCq4CtR/4FlQOKBXInUt4ZhuBBh9kPo2Rw==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/ui":
+  version "4.3.1-dev.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/ui#17782ef782fc9428958e06df947e11bb58e00e6a"
   dependencies:
-    "@faststore/components" "4.1.1"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/946b9932/@faststore/components"
     include-media "^2.0.0"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -4159,6 +4147,13 @@
     tar-fs "^3.1.1"
     yargs "^17.7.2"
 
+"@qwik.dev/partytown@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@qwik.dev/partytown/-/partytown-0.14.0.tgz#242b430489c9d945643f5ac873e6743128d0978e"
+  integrity sha512-ZZITKYRihVGDuK0cn+Y5XJn7Zufum6rHme15ydaUDLpUprPkct+RSGCk1wN5Mep0oareBf4TKMYGBZj3c0A8HA==
+  dependencies:
+    dotenv "^16.4.7"
+
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
@@ -4465,10 +4460,10 @@
     fetch-retry "^4.1.1"
     isomorphic-unfetch "^3.1.0"
 
-"@vtex/client-cp@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@vtex/client-cp/-/client-cp-0.5.1.tgz#af76c015bcc5589fef08a5832b04bda3d3c11de0"
-  integrity sha512-z5ooUZvOl7okcfIgXxviI4Y2TNpotbZBHhseL+AhMsyG+UxijcfqyiNDcQncWKbNmPQY6/kZgjuAh/ENaN+2CA==
+"@vtex/client-cp@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@vtex/client-cp/-/client-cp-0.6.0.tgz#25dd82e1a7f753d5b94fa5f9c7b384a694e41492"
+  integrity sha512-+ijNI8uOIB84oOSZFiEmEcjXe23sK9lwTyvyoB72y1gS7Xfqgwn93F9gzrbYjxerPNZTb8ZSlsGBLWxCx1ONBw==
   dependencies:
     axios "^1.7.7"
 
@@ -6227,6 +6222,11 @@ dotenv@^16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
+dotenv@^16.4.7:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
 draftjs-to-html@^0.9.1:
   version "0.9.1"
@@ -8115,6 +8115,11 @@ jiti@^2.0.0, jiti@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
   integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
+
+jose@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
+  integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
 
 jpeg-js@^0.4.1, jpeg-js@^0.4.3, jpeg-js@^0.4.4:
   version "0.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,14 +1569,14 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-4.2.0.tgz#7eaaa8c08cadfe86bbd4a8924a36880a537291e6"
-  integrity sha512-jQ1jKCubuOjysoLsVuSLgEFypY1BZllwPCkILrWII7mXJGmjC50r8M3243nU8965XZCQ1vnTnj1mSlS1Xw2Qrw==
+"@faststore/cli@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-4.1.2.tgz#d733439075b10c758d1ddb8c14cb08f7fafa87c4"
+  integrity sha512-qI1YWROzDAjMDN70OkX9ErYhK+7sWlOO/xBTayDl50rQrH4P9m1gYKsb+mWiovMeigecyurTmsP5exxEcYy4uQ==
   dependencies:
     "@antfu/ni" "0.21.12"
     "@faststore/api" "4.1.1"
-    "@faststore/core" "4.2.0"
+    "@faststore/core" "4.1.2"
     "@graphql-codegen/cli" "6.1.1"
     "@graphql-tools/merge" "9.1.1"
     "@graphql-tools/utils" "10.10.1"
@@ -1605,10 +1605,10 @@
     react-intersection-observer "^8.32.5"
     react-swipeable "^7.0.0"
 
-"@faststore/core@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-4.2.0.tgz#8c79bcf3162a6537ef2ad651ac05385eb91edda3"
-  integrity sha512-8JLqRK4rmK8HRCyj+8xCVAdg4peQm0QuIsMLPfrYPX7JbFACKgsnW3BndHAu6TPJRoiFRCNbBDAaeqGLU2XUAQ==
+"@faststore/core@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-4.1.2.tgz#001ce40f27a6807830257f011c9e23365e4ff700"
+  integrity sha512-nhxc9W5eZMbC6yY/HBD8RdzQiCeHRQS2ACA5atpiuWtGCfKAtAVXPHA3GNy0QicIZcxo7/5JBoXaryNHfK3q3w==
   dependencies:
     "@antfu/ni" "0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1620,7 +1620,7 @@
     "@faststore/diagnostics" "4.1.1"
     "@faststore/lighthouse" "4.1.1"
     "@faststore/sdk" "4.1.1"
-    "@faststore/ui" "4.2.0"
+    "@faststore/ui" "4.1.1"
     "@graphql-codegen/cli" "6.1.1"
     "@graphql-codegen/client-preset" "4.2.6"
     "@graphql-codegen/typescript" "4.0.7"
@@ -1640,7 +1640,7 @@
     "@lhci/cli" "^0.15.1"
     "@types/react" "^18.3.27"
     "@vtex/client-cms" "^0.2.16"
-    "@vtex/client-cp" "0.6.0"
+    "@vtex/client-cp" "0.5.1"
     "@vtex/prettier-config" "1.0.0"
     autoprefixer "^10.4.0"
     cookie "^0.7.0"
@@ -1688,10 +1688,10 @@
     idb-keyval "^6"
     zustand "^5.0.5"
 
-"@faststore/ui@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-4.2.0.tgz#6d90bfb9b75901282730da7635cd5241a8a4b71c"
-  integrity sha512-1a85O7WdBHbvhAOVs0uBYvVYIyGv9v6ZL7FpcDBShXjk20Anskl4wEvsSbWvj+4FmRiVt/CM2QmJU7XgmyuKyA==
+"@faststore/ui@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-4.1.1.tgz#e385c5f39eebbfaba72ac202ffedf9e992f7e100"
+  integrity sha512-MQs9QFWhkRH63mTIqYl6d30S4e3m2jOZHZPYVDCBW+x1naMIQC5IyCq4CtR/4FlQOKBXInUt4ZhuBBh9kPo2Rw==
   dependencies:
     "@faststore/components" "4.1.1"
     include-media "^2.0.0"
@@ -4465,10 +4465,10 @@
     fetch-retry "^4.1.1"
     isomorphic-unfetch "^3.1.0"
 
-"@vtex/client-cp@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@vtex/client-cp/-/client-cp-0.6.0.tgz#25dd82e1a7f753d5b94fa5f9c7b384a694e41492"
-  integrity sha512-+ijNI8uOIB84oOSZFiEmEcjXe23sK9lwTyvyoB72y1gS7Xfqgwn93F9gzrbYjxerPNZTb8ZSlsGBLWxCx1ONBw==
+"@vtex/client-cp@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@vtex/client-cp/-/client-cp-0.5.1.tgz#af76c015bcc5589fef08a5832b04bda3d3c11de0"
+  integrity sha512-z5ooUZvOl7okcfIgXxviI4Y2TNpotbZBHhseL+AhMsyG+UxijcfqyiNDcQncWKbNmPQY6/kZgjuAh/ENaN+2CA==
   dependencies:
     axios "^1.7.7"
 


### PR DESCRIPTION
## O que

Downgrade do `@faststore/cli` de `4.2.0` para `4.1.2` (`package.json` + `yarn.lock`).

## Por quê

Teste para validar se as páginas do plugin **buyer portal** (rotas `/pvt/organization-account/...`) voltam a renderizar corretamente no **preview do Vercel** com a CLI 4.1.2 em vez da 4.2.0, que vinha apresentando *not found* em produção.

## Como validar

1. Abrir o preview do Vercel gerado por este PR
2. Verificar se as rotas `/pvt/organization-account/...` deixam de dar not found
3. Conferir o **log de build do Vercel** para confirmar que a CLI resolveu/gerou as páginas do plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)