### PR TITLE
chore: bump FastStore and buyer portal for SUMA

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "4.2.0",
+    "@faststore/cli": "4.5.0",
     "graphql": "^16.11.0",
-    "@vtex/faststore-plugin-buyer-portal": "2.0.7",
+    "@vtex/faststore-plugin-buyer-portal": "2.0.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,11 +1407,6 @@
     "@babel/helper-string-parser" "^7.29.7"
     "@babel/helper-validator-identifier" "^7.29.7"
 
-"@builder.io/partytown@^0.6.1":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.6.4.tgz#8610c9e73cc52a95b963c1878760ebe628eee048"
-  integrity sha512-W6C7O0eSg6YNujHYZozXK5iJ+V69QVLLLRv+NlmYh1vFe0PUJ3kmAhRCx7rUqI3XAA/KpdyfdxLoopBg3GlfVA==
-
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -1553,10 +1548,10 @@
   dependencies:
     fast-deep-equal "^3.1.3"
 
-"@faststore/api@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-4.1.1.tgz#3096aaeace5bc5b055fd9ccfdd7a313b42edd913"
-  integrity sha512-PI6O638jCLyOliS80HluB9fiOTX03ixi3dKiBIWD8HyOAUC+Atsi1XFrMG5+4d44r8D6UfPIAW+3ldK7ZfXNNw==
+"@faststore/api@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-4.5.0.tgz#875d4eff6b8d5849435b48cd822a5e9745cdae66"
+  integrity sha512-YjaCKLiDqXVe9AteqOsl+JIFZ8mt0OsWiT6XWpsliSCKpWDHZih613etkBwGKw8KYbatgU+rDO/Xm+0JT96EKg==
   dependencies:
     "@graphql-tools/load-files" "^7.0.0"
     "@graphql-tools/merge" "9.1.1"
@@ -1569,14 +1564,14 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-4.2.0.tgz#7eaaa8c08cadfe86bbd4a8924a36880a537291e6"
-  integrity sha512-jQ1jKCubuOjysoLsVuSLgEFypY1BZllwPCkILrWII7mXJGmjC50r8M3243nU8965XZCQ1vnTnj1mSlS1Xw2Qrw==
+"@faststore/cli@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-4.5.0.tgz#a6fc64d1ccc24fde152afbbdda586dc429e1636c"
+  integrity sha512-4o2bppz7N/jOSFpyKDkIBSjoqcIMqEOqdf9cM9ZTsoyTIdbHdGN9w/kpgXE7z7V7Kl1dTVH0yP6gIgAaVkNakg==
   dependencies:
     "@antfu/ni" "0.21.12"
-    "@faststore/api" "4.1.1"
-    "@faststore/core" "4.2.0"
+    "@faststore/api" "4.5.0"
+    "@faststore/core" "4.5.0"
     "@graphql-codegen/cli" "6.1.1"
     "@graphql-tools/merge" "9.1.1"
     "@graphql-tools/utils" "10.10.1"
@@ -1597,30 +1592,29 @@
     prettier "^3.1.0"
     resolve-pkg "^3.0.0"
 
-"@faststore/components@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-4.1.1.tgz#0cd9f61b1cf2e535488629a89784db206f3dd304"
-  integrity sha512-vNGwg9zPfT/jGgx09U+Jo140DiPXajcHPKFPfdOUnYF4+MZ8RYbZ2owFeDyr51WN56C7PPfSBehHfXnC93diRA==
+"@faststore/components@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-4.5.0.tgz#fcb99abdbe9da3632f6a0d7b2bfb49ed4a7df5a3"
+  integrity sha512-eJsATW4giQgzkfleX3mgRuXxPQQKCrV6yH00M9z/AqFcXxRmpCzqHpHQyTd5QvuWxZhSmNIVBMaohVcpto11rQ==
   dependencies:
     react-intersection-observer "^8.32.5"
     react-swipeable "^7.0.0"
 
-"@faststore/core@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-4.2.0.tgz#8c79bcf3162a6537ef2ad651ac05385eb91edda3"
-  integrity sha512-8JLqRK4rmK8HRCyj+8xCVAdg4peQm0QuIsMLPfrYPX7JbFACKgsnW3BndHAu6TPJRoiFRCNbBDAaeqGLU2XUAQ==
+"@faststore/core@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-4.5.0.tgz#55835395c046a9220f2655010f32ae56ac0585f1"
+  integrity sha512-z1Go3wYEAwGVyPRWIvxdCayspMipSBfB22yHbnw9UXqCvK8cCYIn4FaxQCF4HSTHKweFpjF0iwba3JJY2F1CqQ==
   dependencies:
     "@antfu/ni" "0.21.12"
-    "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^5"
     "@envelop/graphql-jit" "^11"
     "@envelop/parser-cache" "^10"
     "@envelop/validation-cache" "^10"
-    "@faststore/api" "4.1.1"
-    "@faststore/diagnostics" "4.1.1"
-    "@faststore/lighthouse" "4.1.1"
-    "@faststore/sdk" "4.1.1"
-    "@faststore/ui" "4.2.0"
+    "@faststore/api" "4.5.0"
+    "@faststore/diagnostics" "4.5.0"
+    "@faststore/lighthouse" "4.5.0"
+    "@faststore/sdk" "4.5.0"
+    "@faststore/ui" "4.5.0"
     "@graphql-codegen/cli" "6.1.1"
     "@graphql-codegen/client-preset" "4.2.6"
     "@graphql-codegen/typescript" "4.0.7"
@@ -1638,6 +1632,7 @@
     "@lexical/react" "^0.34.0"
     "@lexical/rich-text" "^0.34.0"
     "@lhci/cli" "^0.15.1"
+    "@qwik.dev/partytown" "^0.14.0"
     "@types/react" "^18.3.27"
     "@vtex/client-cms" "^0.2.16"
     "@vtex/client-cp" "0.6.0"
@@ -1651,6 +1646,7 @@
     fs-extra "^10.1.0"
     idb-keyval "^5.1.3"
     isomorphic-unfetch "^3.1.0"
+    jose "^6.2.3"
     lexical "^0.34.0"
     next "^16.2.6"
     next-seo "^6.6.0"
@@ -1664,36 +1660,36 @@
     swr "^2.2.5"
     use-sync-external-store "^1.6.0"
 
-"@faststore/diagnostics@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/diagnostics/-/diagnostics-4.1.1.tgz#e3066e1fec36d340530b6d220a52802a9c45fb67"
-  integrity sha512-0KHJIeMS+kY0rNEz/CQc/W7D5tyPwyF7GYupyIEjjl3aiTPjtZbIjfgTisaPhGt1gp8PKw8zyb58dscVM7WiNQ==
+"@faststore/diagnostics@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/diagnostics/-/diagnostics-4.5.0.tgz#d26cbffd64eef425317be8054df5822d48e88a19"
+  integrity sha512-jW8GscbCp4Jv991z5DmQTjmSHwN50jjx2fanKn1U2qNTtfQ/AVGx6uPh6QYyo6hbNjnzCT7B4DqW9P7y/z3F+w==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/instrumentation-http" "^0.212.0"
     "@vtex/diagnostics-nodejs" "^5.1.1"
     resolve-pkg "^3.0.1"
 
-"@faststore/lighthouse@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-4.1.1.tgz#7a95d00ef34396e38a00701d8b32c3a3a89fd3c4"
-  integrity sha512-m06Yv579gMOFlNk4Q9/oNenMOayW+22s5uMYsrb1TLlnWfOFm6MSqt0zSRQFDZcdPGJc/l8wVsRmPaVjk1MMFA==
+"@faststore/lighthouse@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-4.5.0.tgz#7876a397a3471c5b98e3cf3e92fdd3facd641816"
+  integrity sha512-WElxCoFdPcd+YEqnzdMG4ylX2PRZ5Fret9kyMccPo0ZEYXRjkBbVQsFU9Nri7c5tN3c805CsDIpJ3duzedQIEQ==
 
-"@faststore/sdk@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-4.1.1.tgz#c6de33c8d15d5a476fe9c247ef956b819d190720"
-  integrity sha512-9le4C2vup8ZpVYB1aU4ZuFGqtIPxtl4FTG4556U357GzNzYvEQ3ObNPsdgzfRFTOpg6am3w7NbbHuf1raLCXlg==
+"@faststore/sdk@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-4.5.0.tgz#b4ee274cdf2279ff7190e842f0282f369ac224a8"
+  integrity sha512-pVNuA6iYBNz3knZYTtAMitr32ktRIL8FCZNoPtRxISSXfKEbnV+kDzfI0dB8oSDFUc0EQg3S33yVdeC5lrA+rQ==
   dependencies:
     fast-deep-equal "^3.1.3"
     idb-keyval "^6"
     zustand "^5.0.5"
 
-"@faststore/ui@4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-4.2.0.tgz#6d90bfb9b75901282730da7635cd5241a8a4b71c"
-  integrity sha512-1a85O7WdBHbvhAOVs0uBYvVYIyGv9v6ZL7FpcDBShXjk20Anskl4wEvsSbWvj+4FmRiVt/CM2QmJU7XgmyuKyA==
+"@faststore/ui@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-4.5.0.tgz#f9df3c228d92405314a38c2a73ab836dddde81bc"
+  integrity sha512-O3Xsgo4bB9PKB7t2SC4m5U/1TdFmoRjo8FiGpOu5YUx1Ha72hN974dH0K9VxLZKwY5ZLgbWgpktoDrAlpbyTpg==
   dependencies:
-    "@faststore/components" "4.1.1"
+    "@faststore/components" "4.5.0"
     include-media "^2.0.0"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -4159,6 +4155,13 @@
     tar-fs "^3.1.1"
     yargs "^17.7.2"
 
+"@qwik.dev/partytown@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@qwik.dev/partytown/-/partytown-0.14.0.tgz#242b430489c9d945643f5ac873e6743128d0978e"
+  integrity sha512-ZZITKYRihVGDuK0cn+Y5XJn7Zufum6rHme15ydaUDLpUprPkct+RSGCk1wN5Mep0oareBf4TKMYGBZj3c0A8HA==
+  dependencies:
+    dotenv "^16.4.7"
+
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
@@ -4503,10 +4506,10 @@
   resolved "https://registry.yarnpkg.com/@vtex/diagnostics-semconv/-/diagnostics-semconv-5.1.0.tgz#7669b1940f4c3a34ff23fc7ef35a2fa91164051e"
   integrity sha512-apTPplntetN0y7+A0b6+9qh7SRv5Q7Ox+bQ7e3bY84UBWM6uBrphWeHNJve9DI3H9Y8oA1jjZCtXNamiE7hiWA==
 
-"@vtex/faststore-plugin-buyer-portal@2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@vtex/faststore-plugin-buyer-portal/-/faststore-plugin-buyer-portal-2.0.7.tgz#f73e8129a56419c4fbe5cc2af808ed39ff03b53a"
-  integrity sha512-GnvJI6/b2DpRb1lxxiSxeTZlyVARaHtXcqFPcbtABm/pNGNDWCZoVvZFYT6OkL9Yz5nzEVS/dyT31sGEqAX9Sg==
+"@vtex/faststore-plugin-buyer-portal@2.0.16":
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/@vtex/faststore-plugin-buyer-portal/-/faststore-plugin-buyer-portal-2.0.16.tgz#f2cb68711d0afc7422f207e029bf3345a57d102e"
+  integrity sha512-uuyF1PEDP9bBhf670aFGzvww5t1/G+UWwU8sDWrb93cebTHvWXS5wXhydXOcnyXk/SpFcT4OdEwrRVUxIc9uvw==
 
 "@vtex/faststore-sdk@0.1.1-canary.5":
   version "0.1.1-canary.5"
@@ -6219,6 +6222,11 @@ dotenv@^16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
+dotenv@^16.4.7:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
 draftjs-to-html@^0.9.1:
   version "0.9.1"
@@ -8107,6 +8115,11 @@ jiti@^2.0.0, jiti@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
   integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
+
+jose@^6.2.3:
+  version "6.2.8"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.8.tgz#39c1459fe5eac84eb39b1623b8077dcf9ca6c506"
+  integrity sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==
 
 jpeg-js@^0.4.1, jpeg-js@^0.4.3, jpeg-js@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
## Summary
- Bump `@faststore/cli` from 4.2.0 to 4.5.0 (and transitive FastStore packages to 4.5.0)
- Bump `@vtex/faststore-plugin-buyer-portal` from 2.0.7 to 2.0.16 to enable SUMA

## Test plan
- [x] Install deps (`yarn`) and confirm lockfile resolves cleanly
- [x] Run the store locally and verify buyer portal loads
- [ ] Smoke-test SUMA-related buyer portal flows on this account


Made with [Cursor](https://cursor.com)